### PR TITLE
Solve error when building Example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ link_directories(${OGRE_LIBRARY_DIRS})
 file(COPY ${OGRE_CONFIG_DIR}/plugins.cfg ${OGRE_CONFIG_DIR}/resources.cfg
      DESTINATION ${CMAKE_BINARY_DIR})
 
-set(IMGUI_SRCS ${CMAKE_SOURCE_DIR}/imgui/imgui.cpp ${CMAKE_SOURCE_DIR}/imgui/imgui_draw.cpp)
+set(IMGUI_SRCS ${CMAKE_SOURCE_DIR}/imgui/imgui.cpp ${CMAKE_SOURCE_DIR}/imgui/imgui_draw.cpp ${CMAKE_SOURCE_DIR}/imgui/imgui_widgets.cpp)
 set(OGRE_IMGUI_SRCS ${CMAKE_SOURCE_DIR}/ImguiManager.cpp ${CMAKE_SOURCE_DIR}/ImguiRenderable.cpp)
 if(FREETYPE_FOUND)
     include_directories(${CMAKE_SOURCE_DIR}/imgui/misc/freetype/)


### PR DESCRIPTION
I faced an undefined reference when building the project, and solved it by adding imgui_widgets.cpp in the CMakeLists.txt